### PR TITLE
res/res_respoke_session: Don't hangup a channel that is already gone

### DIFF
--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -1098,7 +1098,9 @@ static int transaction_session_terminate(void *data)
 			session->session_id);
 
 		session->terminated = 1;
-		ast_queue_hangup_with_cause(session->channel, AST_CAUSE_SWITCH_CONGESTION);
+		if (session->channel) {
+			ast_queue_hangup_with_cause(session->channel, AST_CAUSE_SWITCH_CONGESTION);
+		}
 	}
 
 	ao2_ref(transaction, -1);


### PR DESCRIPTION
If things become out of sync with the Respoke service, there is a chance that
we will receive an 'error' message after a channel has already been hung up
and disassociated with the session object. If that is the case, don't try
to hang up a NULL channel. Hilarity in the form of FRACKs and crashing will
ensue.