### PR TITLE
chan_respoke currently sends back 'ulaw' when it should be 'PCMU'

### DIFF
--- a/res/res_respoke/respoke_message_json.c
+++ b/res/res_respoke/respoke_message_json.c
@@ -672,7 +672,7 @@ static struct ast_json *sdp_media_dtls_fingerprint_to_json(struct ast_rtp_engine
 static struct ast_json *sdp_media_rtp_to_json(
 	int payload, struct ast_format *format)
 {
-	const char *codec = ast_format_get_name(format);
+	const char *codec = ast_rtp_lookup_mime_subtype2(1, format, 0, 0);
 
 	return ast_json_pack(
 		"{s:i,s:s,s:i}",


### PR DESCRIPTION
Firefox 37 broke calling

This change changes how codecs are formed - instead of ulaw, it now specifies PCMU which is the standard

Tested and works with Chrome and Firefox stable as well as Chrome Canary and Firefox 39