### PR TITLE
Added Channel Variables and AMI Event for Respoke Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,27 +83,27 @@ To uninstall all files associated with the example issue the following command:
 
 You can use the following Respoke session information to manage them inside the asterisk channel:
 
-- RESPOKE
-- RESPOKE(local)
-- RESPOKE(local_type)
-- RESPOKE(local_connection)
-- RESPOKE(remote)
-- RESPOKE(remote_type)
-- RESPOKE(remote_connection)
-- RESPOKE(remote_appid)
+- RESPOKE_SESSION_LOCAL
+- RESPOKE_SESSION_LOCAL_TYPE
+- RESPOKE_SESSION_LOCAL_CONNECTION
+- RESPOKE_SESSION_REMOTE
+- RESPOKE_SESSION_REMOTE_TYPE
+- RESPOKE_SESSION_REMOTE_CONNECTION
+- RESPOKE_SESSION_REMOTE_APPID
+- RESPOKE_SESSION_ID
 
-Here it is a dialplan example in order to pass the "RESPOKE(remote)" inside an asterisk channel variable:
+Here it is a dialplan example in order to pass the "RESPOKE_SESSION_REMOTE" inside an asterisk channel variable:
 
     exten => your_respoke_endpoint,1,Answer()
-    same => n,NoOp(RESPOKE METADATA: ${RESPOKE(remote)})
+    same => n,NoOp(RESPOKE METADATA: ${RESPOKE_SESSION_REMOTE})
     same => n,Ringing
     same => n,Wait(8)
     same => n,Playback(welcome)
-    same => n,SayAlpha(${RESPOKE(remote)})
+    same => n,SayAlpha(${RESPOKE_SESSION_REMOTE})
     same => n,Dial(SIP/300)
     same => n,Hangup()
 
-In the above example, the "RESPOKE(remote)" information is played back to the caller using the Asterisk application SayAlpha.
+In the above example, the "RESPOKE_SESSION_REMOTE" information is played back to the caller using the Asterisk application SayAlpha.
 
 ## AMI
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ The following Event is available on to the Asterisk Manager Interface:
 
     Event: RespokeSession
     Privilege: system,all
-    channel: RESPOKE/anonymous-00000006
-    id: 98B0F7D7-6AEC-4037-8250-8C5DFA7A2C11
-    local: your_respoke_endpoint
-    local_type: web
-    local_connection:
-    remote: ORDER12345
-    remote_type: web
-    remote_connection: 01749CDF-4BB0-41DB-8D52-30D25954D41A
-    remote_appid:
+    Channel: RESPOKE/anonymous-00000006
+    Id: 98B0F7D7-6AEC-4037-8250-8C5DFA7A2C11
+    Local: your_respoke_endpoint
+    LocalType: web
+    LocalConnection:
+    Remote: ORDER12345
+    RemoteType: web
+    RemoteConnection: 01749CDF-4BB0-41DB-8D52-30D25954D41A
+    RemoteAppId:
 
 In the above example, the AMI "RespokeSession" Event includes the respoke session information, in particular the remote field.

--- a/README.md
+++ b/README.md
@@ -82,24 +82,47 @@ To uninstall all files associated with the example issue the following command:
 ## Asterisk Channel Variables
 
 You can use the following Respoke session information to manage them inside the asterisk channel:
-- respoke_session_local
-- respoke_session_local_type
-- respoke_session_local_connection
-- respoke_session_remote
-- respoke_session_remote_type
-- respoke_session_remote_connection
-- respoke_session_remote_appid
-- respoke_session_id
 
-Here it is a dialplan example in order to pass the "respoke_session_remote" inside an asterisk channel variable:
+- respoke\_session\_local
+- respoke\_session\_local\_type
+- respoke\_session\_local\_connection
+- respoke\_session\_remote
+- respoke\_session\_remote\_type
+- respoke\_session\_remote\_connection
+- respoke\_session\_remote\_appid
+- respoke\_session\_id
 
-exten => your_respoke_endpoint,1,Answer()
-same => n,NoOp(RESPOKE METADATA: ${respoke_session_remote})
-same => n,Ringing
-same => n,Wait(8)
-same => n,Playback(welcome)
-same => n,SayAlpha(${respoke_session_remote})
-same => n,Dial(SIP/300)
-same => n,Hangup()
+Here it is a dialplan example in order to pass the "respoke\_session\_remote" inside an asterisk channel variable:
+
+    exten => your_respoke_endpoint,1,Answer()
+    same => n,NoOp(RESPOKE METADATA: ${respoke_session_remote})
+    same => n,Ringing
+    same => n,Wait(8)
+    same => n,Playback(welcome)
+    same => n,SayAlpha(${respoke_session_remote})
+    same => n,Dial(SIP/300)
+    same => n,Hangup()
+
+In the above example, the "respoke\_session\_remote" information is played back to the caller using the Asterisk application SayAlpha.
 
 ## AMI
+
+The following Event is available on to the Asterisk Manager Interface:
+
+**Event: respoke_session**
+
+##### Example:
+
+    Event: respoke_session
+    Privilege: system,all
+    channel: RESPOKE/anonymous-00000006
+    id: 98B0F7D7-6AEC-4037-8250-8C5DFA7A2C11
+    local: your_respoke_endpoint
+    local_type: web
+    local_connection:
+    remote: ORDER12345
+    remote_type: web
+    remote_connection: 01749CDF-4BB0-41DB-8D52-30D25954D41A
+    remote_appid:
+
+In the above example, the AMI "respoke\_session" Event includes the respoke session information, in particular the remote field.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,28 @@ be heard and the call hung up.
 To uninstall all files associated with the example issue the following command:
 
     make uninstall-example
+
+## Asterisk Channel Variables
+
+You can use the following Respoke session information to manage them inside the asterisk channel:
+- respoke_session_local
+- respoke_session_local_type
+- respoke_session_local_connection
+- respoke_session_remote
+- respoke_session_remote_type
+- respoke_session_remote_connection
+- respoke_session_remote_appid
+- respoke_session_id
+
+Here it is a dialplan example in order to pass the "respoke_session_remote" inside an asterisk channel variable:
+
+exten => your_respoke_endpoint,1,Answer()
+same => n,NoOp(RESPOKE METADATA: ${respoke_session_remote})
+same => n,Ringing
+same => n,Wait(8)
+same => n,Playback(welcome)
+same => n,SayAlpha(${respoke_session_remote})
+same => n,Dial(SIP/300)
+same => n,Hangup()
+
+## AMI

--- a/README.md
+++ b/README.md
@@ -83,37 +83,37 @@ To uninstall all files associated with the example issue the following command:
 
 You can use the following Respoke session information to manage them inside the asterisk channel:
 
-- respoke\_session\_local
-- respoke\_session\_local\_type
-- respoke\_session\_local\_connection
-- respoke\_session\_remote
-- respoke\_session\_remote\_type
-- respoke\_session\_remote\_connection
-- respoke\_session\_remote\_appid
-- respoke\_session\_id
+- RESPOKE
+- RESPOKE(local)
+- RESPOKE(local_type)
+- RESPOKE(local_connection)
+- RESPOKE(remote)
+- RESPOKE(remote_type)
+- RESPOKE(remote_connection)
+- RESPOKE(remote_appid)
 
-Here it is a dialplan example in order to pass the "respoke\_session\_remote" inside an asterisk channel variable:
+Here it is a dialplan example in order to pass the "RESPOKE(remote)" inside an asterisk channel variable:
 
     exten => your_respoke_endpoint,1,Answer()
-    same => n,NoOp(RESPOKE METADATA: ${respoke_session_remote})
+    same => n,NoOp(RESPOKE METADATA: ${RESPOKE(remote)})
     same => n,Ringing
     same => n,Wait(8)
     same => n,Playback(welcome)
-    same => n,SayAlpha(${respoke_session_remote})
+    same => n,SayAlpha(${RESPOKE(remote)})
     same => n,Dial(SIP/300)
     same => n,Hangup()
 
-In the above example, the "respoke\_session\_remote" information is played back to the caller using the Asterisk application SayAlpha.
+In the above example, the "RESPOKE(remote)" information is played back to the caller using the Asterisk application SayAlpha.
 
 ## AMI
 
 The following Event is available on to the Asterisk Manager Interface:
 
-**Event: respoke_session**
+**Event: RespokeSession**
 
 ##### Example:
 
-    Event: respoke_session
+    Event: RespokeSession
     Privilege: system,all
     channel: RESPOKE/anonymous-00000006
     id: 98B0F7D7-6AEC-4037-8250-8C5DFA7A2C11
@@ -125,4 +125,4 @@ The following Event is available on to the Asterisk Manager Interface:
     remote_connection: 01749CDF-4BB0-41DB-8D52-30D25954D41A
     remote_appid:
 
-In the above example, the AMI "respoke\_session" Event includes the respoke session information, in particular the remote field.
+In the above example, the AMI "RespokeSession" Event includes the respoke session information, in particular the remote field.

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -824,14 +824,14 @@ int respoke_session_answer(struct respoke_session *session)
 	{
 		ast_verbose("\n\n<-- Respoke Session Answer: %s -->\n\n", ast_channel_name(session->channel));
 
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local)", session->local);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local_type)", session->local_type);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local_connection)", session->local_connection);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote)", session->remote);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_type)", session->remote_type);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_connection)", session->remote_connection);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_appid)", session->remote_appid);
-		pbx_builtin_setvar_helper(session->channel, "RESPOKE", session->session_id);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_LOCAL", session->local);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_LOCAL_TYPE", session->local_type);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_LOCAL_CONNECTION", session->local_connection);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_REMOTE", session->remote);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_REMOTE_TYPE", session->remote_type);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_REMOTE_CONNECTION", session->remote_connection);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_REMOTE_APPID", session->remote_appid);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_ID", session->session_id);
 
 		manager_event(EVENT_FLAG_SYSTEM, "RespokeSession", "channel: %s\n"
 			"id: %s\nlocal: %s\nlocal_type: %s\nlocal_connection: %s\n"

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -824,16 +824,16 @@ int respoke_session_answer(struct respoke_session *session)
 	{
 		ast_verbose("\n\n<-- Respoke Session Answer: %s -->\n\n", ast_channel_name(session->channel));
 
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_local", session->local);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_local_type", session->local_type);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_local_connection", session->local_connection);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote", session->remote);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_type", session->remote_type);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_connection", session->remote_connection);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_appid", session->remote_appid);
-		pbx_builtin_setvar_helper(session->channel, "respoke_session_id", session->session_id);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local)", session->local);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local_type)", session->local_type);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(local_connection)", session->local_connection);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote)", session->remote);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_type)", session->remote_type);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_connection)", session->remote_connection);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE(remote_appid)", session->remote_appid);
+		pbx_builtin_setvar_helper(session->channel, "RESPOKE", session->session_id);
 
-		manager_event(EVENT_FLAG_SYSTEM, "respoke_session", "channel: %s\n"
+		manager_event(EVENT_FLAG_SYSTEM, "RespokeSession", "channel: %s\n"
 			"id: %s\nlocal: %s\nlocal_type: %s\nlocal_connection: %s\n"
 			"remote: %s\nremote_type: %s\nremote_connection: %s\nremote_appid: %s\r\n",
 			ast_channel_name(session->channel), session->session_id, session->local,

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -44,6 +44,7 @@
 #include "asterisk/causes.h"
 #include "asterisk/uri.h"
 #include "asterisk/callerid.h"
+#include "asterisk/pbx.h"
 
 #include "asterisk/res_respoke_session.h"
 
@@ -819,6 +820,28 @@ int respoke_session_offer(struct respoke_session *session)
 
 int respoke_session_answer(struct respoke_session *session)
 {
+	if (session->channel)
+	{
+		ast_verbose("\n\n<-- Respoke Session Answer: %s -->\n\n", ast_channel_name(session->channel));
+
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_local", session->local);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_local_type", session->local_type);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_local_connection", session->local_connection);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote", session->remote);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_type", session->remote_type);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_connection", session->remote_connection);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_remote_appid", session->remote_appid);
+		pbx_builtin_setvar_helper(session->channel, "respoke_session_id", session->session_id);
+
+		manager_event(EVENT_FLAG_SYSTEM, "respoke_session", "channel: %s\n"
+			"id: %s\nlocal: %s\nlocal_type: %s\nlocal_connection: %s\n"
+			"remote: %s\nremote_type: %s\nremote_connection: %s\nremote_appid: %s\r\n",
+			ast_channel_name(session->channel), session->session_id, session->local,
+			session->local_type, session->local_connection, session->remote, session->remote_type,
+			session->remote_connection, session->remote_appid);
+
+	}
+
 	int res = respoke_session_message_send_and_release(session,
 		respoke_message_create_answer(
 			session->transport, session->endpoint, session->rtp_ipv6,

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -820,9 +820,8 @@ int respoke_session_offer(struct respoke_session *session)
 
 int respoke_session_answer(struct respoke_session *session)
 {
-	if (session->channel)
-	{
-		ast_verbose("\n\n<-- Respoke Session Answer: %s -->\n\n", ast_channel_name(session->channel));
+	if (session->channel) {
+		ast_verb(4, "\n\n<-- Respoke Session Answer: %s -->\n\n", ast_channel_name(session->channel));
 
 		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_LOCAL", session->local);
 		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_LOCAL_TYPE", session->local_type);
@@ -833,9 +832,9 @@ int respoke_session_answer(struct respoke_session *session)
 		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_REMOTE_APPID", session->remote_appid);
 		pbx_builtin_setvar_helper(session->channel, "RESPOKE_SESSION_ID", session->session_id);
 
-		manager_event(EVENT_FLAG_SYSTEM, "RespokeSession", "channel: %s\n"
-			"id: %s\nlocal: %s\nlocal_type: %s\nlocal_connection: %s\n"
-			"remote: %s\nremote_type: %s\nremote_connection: %s\nremote_appid: %s\r\n",
+		manager_event(EVENT_FLAG_SYSTEM, "RespokeSession", "Channel: %s\n"
+			"Id: %s\nLocal: %s\nLocalType: %s\nLocalConnection: %s\n"
+			"Remote: %s\nRemoteType: %s\nRemoteConnection: %s\nRemoteAppId: %s\r\n",
 			ast_channel_name(session->channel), session->session_id, session->local,
 			session->local_type, session->local_connection, session->remote, session->remote_type,
 			session->remote_connection, session->remote_appid);


### PR DESCRIPTION
Added two new features:

1. Set of Asterisk Channel Variables related to the Respoke Session
2. AMI (Asterisk Manager Interface) new Event 'respoke_session' in order to show the Respoke Session information.

The purpose of such features is to make Respoke information available both on the asterisk channel and on the asterisk manager interface.