### PR TITLE
Handle connect message

### DIFF
--- a/res/res_respoke/respoke_message.c
+++ b/res/res_respoke/respoke_message.c
@@ -227,8 +227,7 @@ static int message_dispatcher(void *data)
 	}
 
 	if (!found) {
-		respoke_message_send_error_from_message(
-			message, NULL, NULL, "Unknown signal type received");
+		ast_log(LOG_WARNING, "Unknown signal type received: %s\n", signal_type);
 	}
 
 	return 0;

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -1087,6 +1087,18 @@ struct respoke_message_handler error_handler = {
 	.receive_message = receive_error
 };
 
+static unsigned int receive_connect(struct respoke_transaction *transaction, struct respoke_message *message)
+{
+	/* Informational message; no-op */
+	return 0;
+}
+
+struct respoke_message_handler connect_handler = {
+	.types = "signal",
+	.signaltypes = "connect",
+	.receive_message = receive_connect
+};
+
 /*! \brief Task which terminates the session */
 static int transaction_session_terminate(void *data)
 {
@@ -1166,7 +1178,8 @@ static int load_module(void)
 	    respoke_register_message_handler(&ice_candidates_handler) ||
 #endif
 	    respoke_register_message_handler(&bye_handler) ||
-	    respoke_register_message_handler(&error_handler)) {
+	    respoke_register_message_handler(&error_handler) ||
+	    respoke_register_message_handler(&connect_handler)) {
 		unload_module();
 		return AST_MODULE_LOAD_FAILURE;
 	}


### PR DESCRIPTION
Instead of responding with an error on connect messages, ignore them. In
addition, when receiving unknown signal types, it's better to just emit a
warning instead of responding with an error.