### PR TITLE
Proper heartbeat handling

### DIFF
--- a/include/asterisk/res_socket_io.h
+++ b/include/asterisk/res_socket_io.h
@@ -89,7 +89,7 @@ struct ast_socket_io_transport {
 	/*!
 	 * \brief Receive data over the transport.
 	 */
-	int (*recv)(void *obj, char **buf);
+	int (*recv)(void *obj, char **buf, unsigned int timeout_secs);
 	/*!
 	 * \brief Retrieves the transport's module.
 	 */


### PR DESCRIPTION
Socket.io heartbeats do not work the way you would think they work given
their property names. From a client perspective, if it hasn't heard any
data from the server in 'heartbeat timeout' seconds, then it should
close the connection and consider it dead.

Independently, if it receives any heartbeat packets it should respond
with a heartbeat packet.