### PR TITLE
Adding version and dist support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.so
 *.i
 TAGS
+.version
+res/res_respoke/respoke_version.c
+chan_respoke*.tar
+chan_respoke*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(if $(shell build_tools/get_asterisk_version $(AST_EXECS_DIR) $(AST_VERSION)), 
 RES_RESPOKE_DIR=res/res_respoke
 RES_RESPOKE_TARGET=res/res_respoke.so
 RES_RESPOKE_SRC=$(RES_RESPOKE_TARGET:.so=.c)
-RES_RESPOKE_SRCS=$(wildcard $(RES_RESPOKE_DIR)/*.c)
+RES_RESPOKE_SRCS=$(wildcard $(RES_RESPOKE_DIR)/*.c) res/res_respoke/respoke_version.c
 RES_RESPOKE_OBJS=$(RES_RESPOKE_SRCS:.c=.o) $(RES_RESPOKE_TARGET:.so=.o)
 
 # test modules
@@ -123,6 +123,11 @@ clean:
 	find . -type f -name "*.o" -delete
 	find . -type f -name "*.so" -delete
 
+distclean: clean
+	rm -f .version
+	rm -f res/res_respoke/respoke_version.c
+	rm -f chan_respoke*.tar.gz
+
 install: all
 	install -m 644 include/asterisk/*.h $(AST_INCLUDE_DIR)
 	find . -type f -name "*.so" -exec install -m 755 {} $(AST_MODULES_DIR) \;
@@ -133,5 +138,14 @@ uninstall:
 	$(RM) $(AST_MODULES_DIR)/*socket_io*.so
 	$(RM) $(AST_MODULES_DIR)/*respoke*.so
 
+dist: .version
+	build_tools/make_dist
+
+.version:
+	@build_tools/make_version
+
+res/res_respoke/respoke_version.c: .version
+	build_tools/make_version_c > $@
+
 .PHONY: all clean install uninstall debug tests install-example \
-	uninstall-example install-keys uninstall-keys
+	uninstall-example install-keys uninstall-keys .version dist distclean

--- a/build_tools/make_dist
+++ b/build_tools/make_dist
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# Build chan_respoke tarball
+#
+
+VERSION=$(git describe --always)
+PREFIX=chan_respoke-${VERSION}
+
+set -ex
+
+# shenanigans for a portable tar --transform
+WORKDIR=$(mktemp -d /tmp/chan_respoke.XXXXXX)
+trap "rm -rf ${WORKDIR}" EXIT
+
+ln -sf $(pwd) ${WORKDIR}/${PREFIX}
+
+tar -C ${WORKDIR} -czf ${PREFIX}.tar.gz \
+    ${PREFIX}/.version \
+    $(git ls-files | sed "s#^#${PREFIX}/#")

--- a/build_tools/make_version
+++ b/build_tools/make_version
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# Update the .version file, if necessary
+#
+
+set -e
+
+if test -d .git; then
+    VERSION=$(git describe --always)
+else
+    VERSION=unknown
+fi
+
+if test -f .version && test "${VERSION}" = "$(cat .version)"; then
+    # .version file up to date; exit
+    exit 0
+fi
+
+echo "${VERSION}" > .version

--- a/build_tools/make_version_c
+++ b/build_tools/make_version_c
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#
+# Create a version header from a .version file.
+#
+
+RESPOKE_VERSION=$(cat .version)
+
+cat <<EOF
+/*
+ * respoke_version.c
+ * Automagically generated
+ */
+
+#include "asterisk.h"
+
+#include "respoke_version.h"
+
+static const char respoke_version[] = "${RESPOKE_VERSION}";
+
+const char *respoke_get_version(void)
+{
+	return respoke_version;
+}
+EOF

--- a/res/res_respoke/include/respoke_version.h
+++ b/res/res_respoke/include/respoke_version.h
@@ -1,0 +1,34 @@
+/*
+ * Respoke - Web communications made easy
+ *
+ * Copyright (C) 2015, D.C.S. LLC
+ *
+ * David M. Lee, II <dlee@respoke.io>
+ *
+ * See https://www.respoke.io for more information about
+ * Respoke. Please do not directly contact any of the
+ * maintainers of this project for assistance.
+ * Respoke offers a community forum to submit and discuss
+ * issues at http://community.respoke.io; please raise any
+ * issues there.
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+#ifndef RESPOKE_VERSION_H
+#define RESPOKE_VERSION_H
+
+/*!
+ * \brief Respoke version.
+ */
+const char *respoke_get_version(void);
+
+#endif /* RESPOKE_VERSION_H */

--- a/res/res_respoke/respoke_app.c
+++ b/res/res_respoke/respoke_app.c
@@ -25,7 +25,6 @@
 
 #include "asterisk.h"
 
-#include "asterisk/cli.h"
 #include "asterisk/format.h"
 #include "asterisk/format_cap.h"
 #include "asterisk/sorcery.h"


### PR DESCRIPTION
* Builds the version into res_respoke
* Adds the `respoke show version` command to get it
* Adds a `make dist` target for building versioned tarballs