### PR TITLE
Add Respoke-SDK header to ws connect and requests

### DIFF
--- a/res/res_respoke/include/respoke_sdk_header.h
+++ b/res/res_respoke/include/respoke_sdk_header.h
@@ -1,0 +1,33 @@
+/*
+ * Respoke - Web communications made easy
+ *
+ * Copyright (C) 2015, D.C.S. LLC
+ *
+ * Chad McElligott <cmcelligott@digium.com> 
+ *
+ * See https://www.respoke.io for more information about
+ * Respoke. Please do not directly contact any of the
+ * maintainers of this project for assistance.
+ * Respoke offers a community forum to submit and discuss
+ * issues at http://community.respoke.io; please raise any
+ * issues there.
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+*/
+
+#ifndef RESPOKE_SDK_HEADER_H_
+#define RESPOKE_SDK_HEADER_H_
+
+#include <stddef.h>
+
+int respoke_get_sdk_header(char *buf, size_t len);
+
+#endif /* RESPOKE_SDK_HEADER_H_ */

--- a/res/res_respoke/respoke_message_json.c
+++ b/res/res_respoke/respoke_message_json.c
@@ -37,6 +37,7 @@
 #include "asterisk/respoke_message.h"
 #include "asterisk/respoke_transport.h"
 #include "include/respoke_app.h"
+#include "include/respoke_sdk_header.h"
 
 #define HEADER "header"
 #define HEADER_TYPE "type"
@@ -1232,15 +1233,19 @@ int respoke_message_sail(struct respoke_message *message)
 {
 	struct ast_json *obj, *headers;
 	struct ast_variable *header;
+	char sdk_header[80] = "";
 
 	/* In case we need to retransmit don't re-sail the message */
 	if (message->sailed) {
 		return 0;
 	}
 
+	respoke_get_sdk_header(sdk_header, sizeof(sdk_header));
+
 	if (!(headers = ast_json_pack(
-		      "{s:s}",
-		      "App-Secret", message->transport->app_secret))) {
+		      "{s:s,s:s}",
+		      "App-Secret", message->transport->app_secret,
+		      "Respoke-SDK", sdk_header))) {
 		return -1;
 	}
 

--- a/res/res_respoke/respoke_sdk_header.c
+++ b/res/res_respoke/respoke_sdk_header.c
@@ -1,0 +1,41 @@
+/*
+ * Respoke - Web communications made easy
+ *
+ * Copyright (C) 2015, D.C.S. LLC
+ *
+ * Chad McElligott <cmcelligott@digium.com> 
+ *
+ * See https://www.respoke.io for more information about
+ * Respoke. Please do not directly contact any of the
+ * maintainers of this project for assistance.
+ * Respoke offers a community forum to submit and discuss
+ * issues at http://community.respoke.io; please raise any
+ * issues there.
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+*/
+
+#include <stddef.h>
+#include <sys/utsname.h>
+#include <stdio.h>
+#include "asterisk/ast_version.h"
+#include "include/respoke_version.h"
+
+int respoke_get_sdk_header(char *buf, size_t len) {
+	const char *asterisk_version = ast_get_version();
+	const char *respoke_version = respoke_get_version();
+	struct utsname un;
+	uname(&un);
+	
+	return snprintf(buf, len-1, 
+			"Respoke-Asterisk/%s (%s %s) Asterisk/%s", 
+			respoke_version, un.sysname, un.release, asterisk_version);
+}


### PR DESCRIPTION
This patch adds the "Respoke-SDK" header to all websocket requests,
as well as to the query string when connecting via websocket to Respoke,
so that Respoke can have some visibility into chan_respoke usage.

<img width="753" alt="screen shot 2015-09-23 at 2 04 03 pm" src="https://cloud.githubusercontent.com/assets/309219/10055478/1074f266-61fc-11e5-80ac-aeb188f8c746.png">
<img width="759" alt="screen shot 2015-09-23 at 2 04 11 pm" src="https://cloud.githubusercontent.com/assets/309219/10055479/107b8fc2-61fc-11e5-8cd6-6eee20067e0b.png">



Related to MER-4340.