### PR TITLE
Add support for retrieving metadata from channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TAGS
 res/res_respoke/respoke_version.c
 chan_respoke*.tar
 chan_respoke*.tar.gz
+*.swp

--- a/channels/chan_respoke.c
+++ b/channels/chan_respoke.c
@@ -274,7 +274,7 @@ static int requester_task(void *obj)
 
 	if (!(data->session = respoke_session_create(
 		      NULL, endpoint, from, from_type, from_connection,
-		      args.target_endpoint, NULL, to_connection, to_appid, NULL, data->caps))) {
+		      args.target_endpoint, NULL, to_connection, to_appid, NULL, data->caps, NULL))) {
 		*data->cause = AST_CAUSE_NO_ROUTE_DESTINATION;
 		ao2_ref(endpoint, -1);
 		return -1;

--- a/funcs/func_respoke_metadata.c
+++ b/funcs/func_respoke_metadata.c
@@ -1,0 +1,164 @@
+/*
+ * Respoke - Web communications made easy
+ *
+ * Copyright (C) 2015, D.C.S. LLC
+ *
+ * Chad McElligott <cmcelligott@respoke.io>
+ * David M. Lee, II <dlee@respoke.io>
+ *
+ * See https://www.respoke.io for more information about
+ * Respoke. Please do not directly contact any of the
+ * maintainers of this project for assistance.
+ * Respoke offers a community forum to submit and discuss
+ * issues at http://community.respoke.io; please raise any
+ * issues there.
+ *
+ * See http://www.asterisk.org for more information about
+ * the Asterisk project. Please do not directly contact
+ * any of the maintainers of this project for assistance;
+ * the project provides a web site, mailing lists and IRC
+ * channels for your use.
+ *
+ * This program is free software, distributed under the terms of
+ * the GNU General Public License Version 2. See the LICENSE file
+ * at the top of the source tree.
+ */
+
+/*! \file
+ *
+ * \brief Retrieve data from a respoke session's metadata
+ *
+ * \author \verbatim Chad McElligott <cmcelligott@respoke.io> \endverbatim
+ * \author \verbatim David M. Lee, II <dlee@respoke.io> \endverbatim
+ *
+ * \ingroup functions
+ *
+ */
+
+/*** MODULEINFO
+	<depend>res_respoke</depend>
+	<depend>res_respoke_session</depend>
+	<support_level>extended</support_level>
+ ***/
+
+#include "asterisk.h"
+
+ASTERISK_FILE_VERSION(__FILE__, "$Revision$")
+
+#include "asterisk/app.h"
+#include "asterisk/pbx.h"
+#include "asterisk/module.h"
+#include "asterisk/channel.h"
+#include "asterisk/json.h"
+
+#include "asterisk/respoke.h"
+#include "asterisk/res_respoke_session.h"
+
+/*** DOCUMENTATION
+	<function name="RESPOKE_METADATA" language="en_US">
+		<synopsis>
+			Get the value at the specified key from a respoke session's metadata, 
+			or the full value of the metadata when no key is provided.
+		</synopsis>
+		<syntax>
+			<parameter name="key" required="true">
+				<para>
+					The key to retrieve the value for. If no such key is found,
+					returns an empty string. If the value at the key is an object or
+					an array, returns the stringified representation of the value.
+					If no key is provided, returns the full value of the session's
+					metadata using the same rules.
+				</para>
+			</parameter>
+		</syntax>
+	</function>
+***/
+
+static int respoke_metadata_function_read(struct ast_channel *chan,
+	const char *cmd, char *data, struct ast_str **buf, ssize_t len)
+{
+	char *parsed_data = ast_strdupa(data);
+	const char *key;
+	const struct respoke_session *session = chan ? ast_channel_tech_pvt(chan) : NULL;
+	struct ast_json *value_json;
+	int res = -1;
+
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(key);
+	);
+
+	if (!session || strncmp(ast_channel_name(chan), "RESPOKE/", 8)) {
+		ast_log(AST_LOG_ERROR, "This function requires a RESPOKE channel.\n");
+		return -1;
+	}
+
+	if (session->metadata == NULL) {
+		ast_debug(1, "No metadata on the respoke channel.\n");
+		return -1;
+	}
+
+	AST_STANDARD_APP_ARGS(args, parsed_data);
+	key = args.key ? args.key : "";
+
+	/* Supplying a complex key will not do the right thing currently, so
+	 * this check is here to prevent anyone from doing that. We can come
+	 * in later and add support for complex keys.
+	 */
+	if (strpbrk(key, "['.\"") != NULL) {
+		ast_log(AST_LOG_ERROR, "Key \"%s\" cannot contain any of [ ' . \"\n", key);
+		return -1;
+	}
+
+	value_json = ast_strlen_zero(key) ?
+		session->metadata : ast_json_object_get(session->metadata, key);
+
+	if (value_json == NULL) {
+		ast_debug(1, "Metadata has no key \"%s\"\n", key);
+		return -1;
+	}
+
+	switch (ast_json_typeof(value_json)) {
+	case AST_JSON_OBJECT:
+	case AST_JSON_ARRAY:
+		res = ast_json_dump_str(value_json, buf);
+		break;
+	case AST_JSON_STRING:
+		res = ast_str_set(buf, len, "%s", ast_json_string_get(value_json));
+		break;
+	case AST_JSON_INTEGER:
+		res = ast_str_set(buf, len, "%jd", ast_json_integer_get(value_json));
+		break;
+	case AST_JSON_REAL:
+		res = ast_str_set(buf, len, "%lf", ast_json_real_get(value_json));
+		break;
+	case AST_JSON_TRUE:
+		res = ast_str_set(buf, len, "true");
+		break;
+	case AST_JSON_FALSE:
+		res = ast_str_set(buf, len, "false");
+		break;
+	case AST_JSON_NULL:
+		res = ast_str_set(buf, len, "null");
+		break;
+	}
+
+	return res < 0 ? -1 : 0;
+}
+
+static struct ast_custom_function respoke_metadata_function = {
+	.name = "RESPOKE_METADATA",
+	.read2 = respoke_metadata_function_read,
+};
+
+static int unload_module(void)
+{
+	return ast_custom_function_unregister(&respoke_metadata_function);
+}
+
+static int load_module(void)
+{
+	return ast_custom_function_register(&respoke_metadata_function);
+}
+
+AST_MODULE_INFO_STANDARD_EXTENDED(ASTERISK_GPL_KEY,
+        "Retrieve data from a respoke session's metadata");

--- a/include/asterisk/res_respoke_session.h
+++ b/include/asterisk/res_respoke_session.h
@@ -72,8 +72,10 @@ struct respoke_session {
 	struct ast_channel *channel;
 	/*! valid capabilities for the session */
 	struct ast_format_cap *capabilities;
-	/* session endpoint identity */
+	/*! session endpoint identity */
 	struct ast_party_id party_id;
+	/*! session metadata */
+	struct ast_json *metadata;
 };
 
 /*!
@@ -90,13 +92,15 @@ struct respoke_session {
  * \param to_appid the to application id
  * \param session_id the id of the session
  * \param caps capabilities the session possibly supports
+ * \param metadata the session metadata
  * \retval A session object.
  */
 struct respoke_session *respoke_session_create(
 	struct respoke_transport *transport, struct respoke_endpoint *endpoint,
 	const char *from, const char *from_type, const char *from_connection,
 	const char *to, const char *to_type, const char *to_connection,
-	const char *to_appid, const char *session_id, struct ast_format_cap *caps);
+	const char *to_appid, const char *session_id, struct ast_format_cap *caps,
+	struct ast_json *metadata);
 
 /*!
  * \brief Retrieve the incoming dialplan destination extension.

--- a/include/asterisk/respoke_message.h
+++ b/include/asterisk/respoke_message.h
@@ -196,6 +196,14 @@ const char *respoke_message_session_id_get(const struct respoke_message *message
 const char *respoke_message_connection_id_get(const struct respoke_message *message);
 
 /*!
+ * \brief Retrieve the message metadata.
+ *
+ * \param message the message object
+ * \retval The message metadata.
+ */
+struct ast_json *respoke_message_metadata_get(const struct respoke_message *message);
+
+/*!
  * \brief Retrieve the DTLS setup value from a media stream.
  *
  * \param message the message object

--- a/res/res_respoke/respoke_message_json.c
+++ b/res/res_respoke/respoke_message_json.c
@@ -64,6 +64,8 @@
 #define BODY_STATUS "status"
 #define BODY_DETAIL "detail"
 
+#define METADATA "metadata"
+
 #define SIGNAL "signal"
 
 #define REDIRECTIONINFO "redirectionInfo"
@@ -238,6 +240,10 @@ const char *respoke_message_connection_id_get(const struct respoke_message *mess
 	return string_get(object_get(message->json, BODY), BODY_CONNECTION_ID);
 }
 
+struct ast_json *respoke_message_metadata_get(const struct respoke_message *message)
+{
+	return object_get(object_get(message->json, BODY), METADATA);
+}
 
 static struct ast_json *message_parsed_sdp_get(const struct respoke_message *message)
 {


### PR DESCRIPTION
This patch adds a new channel function, `RESPOKE_METADATA([<key>])`, to
allow data to be retrieved from a call coming in from a Respoke
endpoint. If no metadata is present on the call, the function will print
a debug message indicating as such. If no key is provided, the function
will return the value of the metadata, which will be a JSON string if
the metadata is an object or an array. If a key is provided and the
metadata is an object that contains that key, the value of the key will
be provided in the same manner.

Related to MER-4452.
Paired with David Lee.