### PR TITLE
Cleanup opus support

### DIFF
--- a/res/res_respoke/respoke_message_json.c
+++ b/res/res_respoke/respoke_message_json.c
@@ -680,17 +680,17 @@ static struct ast_json *sdp_media_rtp_to_json(
 	int payload, struct ast_format *format)
 {
 	const char *codec = ast_rtp_lookup_mime_subtype2(1, format, 0, 0);
-	struct ast_str *rate = ast_str_create(128);
-
-	ast_str_set(&rate, 128, "%i%s", ast_rtp_lookup_sample_rate2(1, format, -1), (strcmp(codec, "opus")) ? "" : "/2" );
-
-	return ast_json_pack(
-		"{s:i,s:s,s:s}",
+	struct ast_json *json = ast_json_pack(
+		"{s:i,s:s,s:i}",
 		"payload", payload,
 		"codec", codec,
-		"rate", ast_str_buffer(rate));
+		"rate", ast_rtp_lookup_sample_rate2(1, format, 0));
 
-	ast_free(rate);
+	if (json && !strcmp(codec, "opus")) {
+		integer_set(json, "encoding", 2);
+	}
+
+	return json;
 }
 
 static struct ast_json *sdp_media_fmtp_to_json(


### PR DESCRIPTION
This patch will move from concatenating the encoding to the rate
when appropriate, to putting the encoding in the correct json
property that it belongs in. This will clarify intent.