### PR TITLE
Makefile:  Update for Asterisk 14 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,13 @@ endef
 all: $(RES_RESPOKE_TARGET) $(MOD_TARGETS)
 
 %.o: %.c
-	$(COMPILE.c) -DAST_MODULE=\"$(notdir $(basename $@))\" \
-		-DAST_MODULE_SELF_SYM=__internal_$(notdir $(basename $@))_self $< -o $@
+	$(COMPILE.c) $(MODULE_CFLAGS) $< -o $@
 
+$(RES_RESPOKE_TARGET): MODULE_CFLAGS = -DAST_MODULE=\"res_respoke\" -DAST_MODULE_SELF_SYM=__internal_res_respoke_self
 $(RES_RESPOKE_TARGET): $(RES_RESPOKE_OBJS)
 	$(mod.link)
 
+$(MOD_TARGETS): MODULE_CFLAGS = -DAST_MODULE=\"$(notdir $(basename $@))\" -DAST_MODULE_SELF_SYM=__internal_$(notdir $(basename $@))_self
 $(MOD_TARGETS): %.so: %.o
 	$(mod.link)
 


### PR DESCRIPTION
Asterisk 14 made changes to the module loader that require
AST_MODULE_SELF_SYM to be defined on the compile command line.