### PR TITLE
Asterisk 14 compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ endef
 all: $(RES_RESPOKE_TARGET) $(MOD_TARGETS)
 
 %.o: %.c
-	$(COMPILE.c) -DAST_MODULE=\"$(notdir $(basename $@))\" $< -o $@
+	$(COMPILE.c) -DAST_MODULE=\"$(notdir $(basename $@))\" \
+		-DAST_MODULE_SELF_SYM=__internal_$(notdir $(basename $@))_self $< -o $@
 
 $(RES_RESPOKE_TARGET): $(RES_RESPOKE_OBJS)
 	$(mod.link)

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,13 @@ endef
 all: $(RES_RESPOKE_TARGET) $(MOD_TARGETS)
 
 %.o: %.c
-	$(COMPILE.c) -DAST_MODULE=\"$(notdir $(basename $@))\" \
-		-DAST_MODULE_SELF_SYM=__internal_$(notdir $(basename $@))_self $< -o $@
+	$(COMPILE.c) $(MODULE_CFLAGS) $< -o $@
 
+$(RES_RESPOKE_TARGET): MODULE_CFLAGS = -DAST_MODULE=\"res_respoke\" -DAST_MODULE_SELF_SYM=__internal_res_respoke_self
 $(RES_RESPOKE_TARGET): $(RES_RESPOKE_OBJS)
 	$(mod.link)
 
+$(MOD_TARGETS): MODULE_CFLAGS = -DAST_MODULE=\"$(notdir $(basename $@))\" -DAST_MODULE_SELF_SYM=__internal_$(notdir $(basename $@))_self
 $(MOD_TARGETS): %.so: %.o
 	$(mod.link)
 

--- a/channels/chan_respoke.c
+++ b/channels/chan_respoke.c
@@ -815,6 +815,8 @@ static int load_module(void)
 	return AST_MODULE_LOAD_SUCCESS;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS |
 		AST_MODFLAG_LOAD_ORDER, "Respoke Channel Driver",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,

--- a/funcs/func_respoke_endpoint.c
+++ b/funcs/func_respoke_endpoint.c
@@ -40,7 +40,7 @@
 
 #include "asterisk.h"
 
-ASTERISK_FILE_VERSION(__FILE__, "$Revision: 422579 $")
+ASTERISK_REGISTER_FILE()
 
 #include "asterisk/app.h"
 #include "asterisk/pbx.h"
@@ -158,4 +158,6 @@ static int load_module(void)
 	return ast_custom_function_register(&respoke_endpoint_function);
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO_STANDARD_EXTENDED(ASTERISK_GPL_KEY, "Get information about a Respoke endpoint");

--- a/funcs/func_respoke_metadata.c
+++ b/funcs/func_respoke_metadata.c
@@ -43,7 +43,7 @@
 
 #include "asterisk.h"
 
-ASTERISK_FILE_VERSION(__FILE__, "$Revision$")
+ASTERISK_REGISTER_FILE()
 
 #include "asterisk/app.h"
 #include "asterisk/pbx.h"
@@ -57,7 +57,7 @@ ASTERISK_FILE_VERSION(__FILE__, "$Revision$")
 /*** DOCUMENTATION
 	<function name="RESPOKE_METADATA" language="en_US">
 		<synopsis>
-			Get the value at the specified key from a respoke session's metadata, 
+			Get the value at the specified key from a respoke session's metadata,
 			or the full value of the metadata when no key is provided.
 		</synopsis>
 		<syntax>
@@ -160,5 +160,7 @@ static int load_module(void)
 	return ast_custom_function_register(&respoke_metadata_function);
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO_STANDARD_EXTENDED(ASTERISK_GPL_KEY,
         "Retrieve data from a respoke session's metadata");

--- a/res/res_respoke.c
+++ b/res/res_respoke.c
@@ -183,6 +183,8 @@ static int unload_module(void)
 	return 0;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS | AST_MODFLAG_LOAD_ORDER, "Basic Respoke resource",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,
 		.load = load_module,

--- a/res/res_respoke/respoke_endpoint.c
+++ b/res/res_respoke/respoke_endpoint.c
@@ -315,7 +315,7 @@ static int respoke_endpoint_apply(const struct ast_sorcery *sorcery, void *obj)
 		ast_uri_host(uri),
 		!ast_strlen_zero(ast_uri_port(uri)) ? ":" : "",
 		S_OR(ast_uri_port(uri), ""),
-		app->secret, 
+		app->secret,
 		encoded_sdk_header);
 
 	ao2_ref(uri, -1);

--- a/res/res_respoke/respoke_message.c
+++ b/res/res_respoke/respoke_message.c
@@ -343,4 +343,3 @@ int respoke_message_send_error_from_message(const struct respoke_message *messag
 	va_end(ap);
 	return res;
 }
-

--- a/res/res_respoke/respoke_transport.c
+++ b/res/res_respoke/respoke_transport.c
@@ -274,4 +274,3 @@ void respoke_transport_deinitialize(void)
 {
 	respoke_transport_socket_io_deinitialize();
 }
-

--- a/res/res_respoke_endpoint_identifier_anonymous.c
+++ b/res/res_respoke_endpoint_identifier_anonymous.c
@@ -61,6 +61,8 @@ static int load_module(void)
 		AST_MODULE_LOAD_FAILURE : AST_MODULE_LOAD_SUCCESS;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "Respoke Anonymous endpoint identifier",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,
 		.load = load_module,

--- a/res/res_respoke_endpoint_identifier_from.c
+++ b/res/res_respoke_endpoint_identifier_from.c
@@ -59,6 +59,8 @@ static int load_module(void)
 		AST_MODULE_LOAD_FAILURE : AST_MODULE_LOAD_SUCCESS;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "Respoke from endpoint identifier",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,
 		.load = load_module,

--- a/res/res_respoke_session.c
+++ b/res/res_respoke_session.c
@@ -74,7 +74,6 @@ int respoke_session_register_handler(struct respoke_session_handler *handler)
 	SCOPED_LOCK(lock, &session_handlers, AST_RWLIST_WRLOCK, AST_RWLIST_UNLOCK);
 	AST_RWLIST_INSERT_TAIL(&session_handlers, handler, item);
 	ast_module_ref(ast_module_info->self);
-
 	return 0;
 }
 
@@ -1206,6 +1205,8 @@ static int load_module(void)
 	return AST_MODULE_LOAD_SUCCESS;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS |
 		AST_MODFLAG_LOAD_ORDER, "Respoke Session Resource",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,

--- a/res/res_socket_io.c
+++ b/res/res_socket_io.c
@@ -1182,6 +1182,8 @@ static int unload_module(void)
 	return 0;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_GLOBAL_SYMBOLS | AST_MODFLAG_LOAD_ORDER, "Socket IO Support",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,
 		.load = load_module,

--- a/res/res_socket_io_websocket.c
+++ b/res/res_socket_io_websocket.c
@@ -145,11 +145,11 @@ static int unload_module(void)
 	return 0;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_LOAD_ORDER, "Socket IO Transport Websocket",
 		.support_level = AST_MODULE_SUPPORT_EXTENDED,
 		.load = load_module,
 		.unload = unload_module,
 		.load_pri = AST_MODPRI_DEFAULT,
 );
-
-

--- a/tests/test_respoke_modules.c
+++ b/tests/test_respoke_modules.c
@@ -31,7 +31,7 @@
 
 #include "asterisk.h"
 
-ASTERISK_FILE_VERSION(__FILE__, "$Revision: 420778 $")
+ASTERISK_REGISTER_FILE()
 
 #include "asterisk/module.h"
 #include "asterisk/test.h"
@@ -169,6 +169,8 @@ static int load_module(void)
 	return AST_MODULE_LOAD_SUCCESS;
 }
 
+#undef AST_BUILDOPT_SUM
+#define AST_BUILDOPT_SUM ""
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "Respoke module testing",
 	.support_level = AST_MODULE_SUPPORT_EXTENDED,
 	.load = load_module,


### PR DESCRIPTION
There were some changes required by Asterisk 14 to get this module to compile and run successfully:

- define AST_MODULE_SELF_SYM when compiling
- replace use of ASTERISK_FILE_VERSION macro with
ASTERISK_REGISTER_FILE
- replace references to module_info->self and remove helper
methods to get reference to module_info
- redefine AST_BUILDOPT_SUM prior to calling AST_MODULE_INFO

There is an open question about whether these changes are backwards compatible with Asterisk 13. Does anyone know the answer to that or do we need to test it out?

