### PR TITLE
Prevent make_version overwriting valid .version

### DIFF
--- a/build_tools/make_version
+++ b/build_tools/make_version
@@ -12,9 +12,16 @@ else
     VERSION=unknown
 fi
 
-if test -f .version && test "${VERSION}" = "$(cat .version)"; then
-    # .version file up to date; exit
-    exit 0
+if test -f .version; then
+	if test "${VERSION}" = "$(cat .version)"; then
+		# .version file up to date
+		exit 0
+	fi
+
+	if test "${VERSION}" = "unknown"; then
+		# don't overwrite an existing .version with "unknown"
+		exit 0
+	fi
 fi
 
 echo "${VERSION}" > .version


### PR DESCRIPTION
Currently when a release is created with `make dist`, it generates
a .version file that is meant to be used by the build process on a
machine that is compiling chan_respoke from an extracted tar
instead of a git checkout. The build_tools/make_version script
takes into consideration an existing .version file, but will
incorrectly overwrite it with a value of 'unknown' when the build
is being run from an extracted tar.

This patch modifies the make_version script to prevent overwriting
an existing .version file with a value of 'unknown'.

Closes #21.