### PR TITLE
Document release process on non-Asterisk box

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,11 @@ be heard and the call hung up.
 To uninstall all files associated with the example issue the following command:
 
     make uninstall-example
+
+## Building for Distribution
+
+To build a tar to attach to the github release, run `make dist`. Note: using
+the Makefile checks for Asterisk to be installed on the system. If you don't
+have Asterisk on your system but still need to cut a new release, you can
+run `./build_tools/make_version && ./build_tools/make_dist` to generate the
+tar with the appropriate .version file in it.


### PR DESCRIPTION
When cutting a new release, part of the process is generating
a tar file that can be attached to the github release that has
the appropriate .version file referencing the git tag. The normal
way of generating this tar file is with the `make dist` command.
However, `make dist` also checks for Asterisk to be installed,
since the Makefile is primarily a build tool.

You don't need Asterisk to be installed to build the release tar
file, so this patch adds documentation on how to build it without
using the make target.

Closes #22.