### PR TITLE
Allow ARI object manipulation routines to function with res_respoke

### DIFF
--- a/include/asterisk/respoke_endpoint.h
+++ b/include/asterisk/respoke_endpoint.h
@@ -43,6 +43,8 @@ struct respoke_endpoint_state {
 	struct respoke_transport *transport;
 	/*! The application the endpoint is configured with */
 	struct respoke_app *app;
+	/* The endpoint name that this state belongs to. */
+	char name[];
 };
 
 /*!
@@ -104,8 +106,6 @@ struct respoke_endpoint {
 	unsigned int register_with_service;
 	/*! Media configuration */
 	struct respoke_endpoint_media media;
-	/*! Optional state information, if registering with service */
-	struct respoke_endpoint_state *state;
 	/*! How to handle redirects received */
 	enum respoke_endpoint_redirect redirect;
 };

--- a/include/asterisk/respoke_endpoint.h
+++ b/include/asterisk/respoke_endpoint.h
@@ -161,4 +161,14 @@ void respoke_unregister_endpoint_identifier(const struct respoke_endpoint_identi
 struct respoke_endpoint *respoke_endpoint_identify(
 	struct respoke_message *message);
 
+/*!
+ * \brief Retrieve the state object for a Respoke endpoint
+ *
+ * \param name The name of the Respoke endpoint
+ *
+ * \retval NULL if the endpoint has no state
+ * \retval state on success
+ */
+struct respoke_endpoint_state *respoke_endpoint_state_retrieve(const char *name);
+
 #endif /* RESPOKE_ENDPOINT_H_ */

--- a/res/res_respoke/respoke_endpoint.c
+++ b/res/res_respoke/respoke_endpoint.c
@@ -208,7 +208,7 @@ static void respoke_endpoint_state_destroy(void *obj)
 	ao2_cleanup(state->app);
 }
 
-static struct respoke_endpoint_state *respoke_endpoint_state_retrieve(const char *name)
+struct respoke_endpoint_state *respoke_endpoint_state_retrieve(const char *name)
 {
 	RAII_VAR(struct ao2_container *, states, ao2_global_obj_ref(endpoint_states), ao2_cleanup);
 

--- a/res/res_respoke/respoke_transport.c
+++ b/res/res_respoke/respoke_transport.c
@@ -129,6 +129,7 @@ struct respoke_transport_state {
 static void respoke_transport_state_destroy(void *obj)
 {
 	struct respoke_transport_state *state = obj;
+
 	ao2_cleanup(state->data);
 	ao2_cleanup(state->callback_data);
 }

--- a/res/res_respoke/respoke_transport_socket_io.c
+++ b/res/res_respoke/respoke_transport_socket_io.c
@@ -48,8 +48,10 @@ static void socket_io_state_destroy(void *obj)
 	/* tell the messaging thread to stop */
 	ast_socket_io_stop(state->session);
 	state->stop = 1;
-	pthread_kill(state->recv_thread, SIGURG);
-	pthread_join(state->recv_thread, NULL);
+	if (state->recv_thread != AST_PTHREADT_NULL) {
+		pthread_kill(state->recv_thread, SIGURG);
+		pthread_join(state->recv_thread, NULL);
+	}
 
 	ao2_ref(state->namespace, -1);
 	ao2_ref(state->session, -1);


### PR DESCRIPTION
ARI has the ability to create/delete objects managed by Sorcery. Today, using those with res_respoke would cause a crash due to infinite recursion in respoke_endpoint_alloc.

This patch fixes that by removing the mutable state stored in the respoke_endpoint object, which has to be treated as immutable (and really always should have been treated as immutable) for the ARI commands to function properly.